### PR TITLE
Revert "Disable stackprotectorstrong"

### DIFF
--- a/scripts/Dpkg/Vendor/Debian.pm
+++ b/scripts/Dpkg/Vendor/Debian.pm
@@ -182,7 +182,7 @@ sub _add_hardening_flags {
     my %use_feature = (
 	pie => 0,
 	stackprotector => 1,
-	stackprotectorstrong => 0,
+	stackprotectorstrong => 1,
 	fortify => 1,
 	format => 1,
 	relro => 1,


### PR DESCRIPTION
This reverts commit 48a4c5bd536780099117d43675624a1ff262632e.
We now have gcc-4.9 so we can go with the configuration shipped
by Debian/Ubuntu.

[endlessm/eos-shell#4716]
