### PR TITLE
Dpkg::Shlibs: Don't resolve library directory symlinks

### DIFF
--- a/scripts/Dpkg/Shlibs.pm
+++ b/scripts/Dpkg/Shlibs.pm
@@ -128,16 +128,6 @@ sub find_library {
     my @rpath = @{$rpath};
     foreach my $dir (@rpath, @librarypaths) {
 	my $checkdir = "$root$dir";
-	# If the directory checked is a symlink, check if it doesn't
-	# resolve to another public directory (which is then the canonical
-	# directory to use instead of this one). Typical example
-	# is /usr/lib64 -> /usr/lib on amd64.
-	if (-l $checkdir) {
-	    my $newdir = resolve_symlink($checkdir);
-	    if (any { "$root$_" eq "$newdir" } (@rpath, @librarypaths)) {
-		$checkdir = $newdir;
-	    }
-	}
 	if (-e "$checkdir/$lib") {
 	    my $libformat = Dpkg::Shlibs::Objdump::get_format("$checkdir/$lib");
 	    if ($format eq $libformat) {


### PR DESCRIPTION
This breaks on Endless where /lib is a symlink to /usr/lib but the
binary packages still use the non-symlinked path. E.g., it would prefer
/usr/lib/ld-linux.so.2 even though libc6 stores the path as
/lib/ld-linux.so.2.

The case this was trying to handle is the opposite of what we're trying
to do. The resolved path (/usr/lib) is the canonical path for the
original (/usr/lib64). For us, the original is the canonical path.

[endlessm/eos-shell#5276]
