### PR TITLE
Support xdg-app builds

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -121,7 +121,8 @@ Section: perl
 Priority: optional
 Architecture: all
 Multi-Arch: foreign
-Depends: dpkg (>= 1.15.8), perl, libtimedate-perl, ${misc:Depends}
+Depends: dpkg (>= 1.15.8), perl, libtimedate-perl, libxml-libxml-perl,
+ ${misc:Depends}
 Recommends: libfile-fcntllock-perl, bzip2, xz-utils
 Suggests: debian-keyring, gnupg | gnupg2, gpgv | gpgv2,
  gcc | c-compiler, binutils, patch

--- a/scripts/Dpkg/BuildFlags.pm
+++ b/scripts/Dpkg/BuildFlags.pm
@@ -178,7 +178,7 @@ sub load_eosapp_config {
     my ($self) = @_;
     my @build_profiles = get_build_profiles();
 
-    if ("eos-app" ~~ @build_profiles) {
+    if (grep {/^eos-app$/} @build_profiles) {
         my $control = Dpkg::Control::Info->new();
         my $mainpackage = $control->get_pkg_by_idx(1);
         my $app_id = $mainpackage->{'Xcbs-Eos-Appid'} || $mainpackage->{'Package'};

--- a/scripts/Dpkg/BuildFlags.pm
+++ b/scripts/Dpkg/BuildFlags.pm
@@ -24,8 +24,6 @@ use Dpkg ();
 use Dpkg::Gettext;
 use Dpkg::BuildEnv;
 use Dpkg::BuildOptions;
-use Dpkg::BuildProfiles qw(get_build_profiles);
-use Dpkg::Control::Info;
 use Dpkg::ErrorHandling;
 use Dpkg::Vendor qw(run_vendor_hook);
 
@@ -168,40 +166,6 @@ sub load_environment_config {
     }
 }
 
-=item $bf->load_eosapp_config()
-
-Update flags for eos-app build profiles.
-
-=cut
-
-sub load_eosapp_config {
-    my ($self) = @_;
-    my @build_profiles = get_build_profiles();
-
-    if (grep {/^eos-app$/} @build_profiles) {
-        my $control = Dpkg::Control::Info->new();
-        my $mainpackage = $control->get_pkg_by_idx(1);
-        my $app_id = $mainpackage->{'Xcbs-Eos-Appid'} || $mainpackage->{'Package'};
-        my $app_prefix = "/endless/" . $app_id;
-
-        # Header search path
-        my $includepath = $app_prefix . '/include';
-        $self->append('CPPFLAGS', '-I' . $includepath, 'eos-app');
-        $self->append('CFLAGS', '-I' . $includepath, 'eos-app');
-        $self->append('CXXFLAGS', '-I' . $includepath, 'eos-app');
-
-        # Library search and run path
-        my $libpath = $app_prefix . '/lib';
-        if ($ENV{DEB_HOST_MULTIARCH}) {
-            my $archlibpath = $libpath . '/' . $ENV{DEB_HOST_MULTIARCH};
-            $self->append('LDFLAGS', '-L' . $archlibpath, 'eos-app');
-            $self->append('LDFLAGS', '-Wl,-rpath,' . $archlibpath, 'eos-app');
-        }
-        $self->append('LDFLAGS', '-L' . $libpath, 'eos-app');
-        $self->append('LDFLAGS', '-Wl,-rpath,' . $libpath, 'eos-app');
-    }
-}
-
 =item $bf->load_maintainer_config()
 
 Update flags based on maintainer directives stored in the environment. See
@@ -235,9 +199,8 @@ sub load_maintainer_config {
 =item $bf->load_config()
 
 Call successively load_system_config(), load_user_config(),
-load_environment_config(), load_eosapp_config and
-load_maintainer_config() to update the default build flags defined by
-the vendor.
+load_environment_config() and load_maintainer_config() to update the
+default build flags defined by the vendor.
 
 =cut
 
@@ -246,7 +209,6 @@ sub load_config {
     $self->load_system_config();
     $self->load_user_config();
     $self->load_environment_config();
-    $self->load_eosapp_config();
     $self->load_maintainer_config();
 }
 

--- a/scripts/Dpkg/Vendor/Default.pm
+++ b/scripts/Dpkg/Vendor/Default.pm
@@ -104,6 +104,13 @@ The hook is called in Dpkg::BuildFlags to allow the vendor to override
 the default values set for the various build flags. $flags is a
 Dpkg::BuildFlags object.
 
+=item update-binary-control-fields ($fields, $builddir)
+
+This hook is called by dpkg-gencontrol after the Dpkg::Control fields
+have been filled in and prior to processing the command line overrides.
+$fields is is a Dpkg::Control object of type CTRL_PKG_DEB and $builddir
+is the package build directory.
+
 =back
 
 =cut
@@ -123,6 +130,8 @@ sub run_hook {
 	my ($textref, $ch_info) = @params;
     } elsif ($hook eq 'update-buildflags') {
 	my $flags = shift @params;
+    } elsif ($hook eq 'update-binary-control-fields') {
+        my ($fields, $builddir) = @params;
     }
 
     # Default return value for unknown/unimplemented hooks

--- a/scripts/Dpkg/Vendor/Ubuntu.pm
+++ b/scripts/Dpkg/Vendor/Ubuntu.pm
@@ -149,13 +149,21 @@ sub run_hook {
 	}
 
 	# Set flags for non-/usr prefix
-	if (grep {/^eos-app$/} get_build_profiles()) {
-	    # Endless bundles have per-app /endless/$app prefix
-	    require Dpkg::Control::Info;
-	    my $control = Dpkg::Control::Info->new();
-	    my $mainpackage = $control->get_pkg_by_idx(1);
-	    my $app_id = $mainpackage->{'Xcbs-Eos-Appid'} || $mainpackage->{'Package'};
-	    my $prefix = "/endless/$app_id";
+	my @build_profiles = get_build_profiles();
+	if (grep {/^(xdg-app|eos-app)$/} @build_profiles) {
+	    my $prefix;
+
+	    if (grep {/^xdg-app$/} @build_profiles) {
+		# Xdg-App always uses /app prefix
+		$prefix = '/app';
+	    } elsif (grep {/^eos-app$/} @build_profiles) {
+		# Endless bundles have per-app /endless/$app prefix
+                require Dpkg::Control::Info;
+		my $control = Dpkg::Control::Info->new();
+		my $mainpackage = $control->get_pkg_by_idx(1);
+		my $app_id = $mainpackage->{'Xcbs-Eos-Appid'} || $mainpackage->{'Package'};
+		$prefix = "/endless/$app_id";
+	    }
 
 	    # Header search path
 	    my $includepath = "$prefix/include";

--- a/scripts/Dpkg/Vendor/Ubuntu.pm
+++ b/scripts/Dpkg/Vendor/Ubuntu.pm
@@ -49,6 +49,7 @@ to check that Maintainers have been modified if necessary.
 
 sub run_hook {
     my ($self, $hook, @params) = @_;
+    my @build_profiles = get_build_profiles();
 
     if ($hook eq 'before-source-build') {
         my $src = shift @params;
@@ -81,6 +82,7 @@ sub run_hook {
         push @field_ops,
             [ 'register', 'Launchpad-Bugs-Fixed',
               CTRL_FILE_CHANGES | CTRL_CHANGELOG  ],
+            [ 'register', 'Xdg-App', CTRL_PKG_DEB ],
             [ 'insert_after', CTRL_FILE_CHANGES, 'Closes', 'Launchpad-Bugs-Fixed' ],
             [ 'insert_after', CTRL_CHANGELOG, 'Closes', 'Launchpad-Bugs-Fixed' ];
         return @field_ops;
@@ -149,7 +151,6 @@ sub run_hook {
 	}
 
 	# Set flags for non-/usr prefix
-	my @build_profiles = get_build_profiles();
 	if (grep {/^(xdg-app|eos-app)$/} @build_profiles) {
 	    my $prefix;
 
@@ -180,6 +181,57 @@ sub run_hook {
 	    }
 	    $flags->append('LDFLAGS', "-L$libpath");
 	    $flags->append('LDFLAGS', "-Wl,-rpath,$libpath");
+	}
+
+    } elsif ($hook eq 'update-binary-control-fields') {
+	my ($fields, $builddir) = @params;
+
+	# Only updating fields for xdg-app builds
+	if (not grep {/^xdg-app$/} @build_profiles) {
+	    return;
+	}
+
+	my @appdata = glob "$builddir/app/share/appdata/*.xml";
+	my $numapps = scalar(@appdata);
+	if ($numapps == 0) {
+	    # Not an app, nothing to do
+	    return;
+	} elsif ($numapps > 1) {
+	    warning(_g('more than 1 appdata file found in %s, skipping ' .
+		       'Xdg-App field', "$builddir/app/share/appdata"));
+	    return;
+	}
+
+	# Get the app id from the appdata. Can't have a hard dependency
+	# on libxml-libxml-perl since it's a binary module and that
+	# would make perl ABI upgrades impossible.
+	require XML::LibXML;
+
+	my $parser = XML::LibXML->new();
+	my $xml = $parser->parse_file($appdata[0]);
+	my $root = $xml->documentElement();
+
+	# Apps are either <component type="desktop"> or <application>.
+	# In both cases, the app ID is in the <id> child node with
+	# .desktop in the name.
+	if ($root->nodeName eq 'component') {
+	    my $type = $root->getAttribute('type');
+	    if (!defined $type || $type ne 'desktop') {
+		return;
+	    }
+	} elsif ($root->nodeName ne 'application') {
+	    return;
+	}
+
+	my $appid = $root->findvalue('id');
+	if ($appid) {
+	    # Strip the desktop suffix
+	    $appid =~ s/\.desktop$//;
+	    info(_g('setting Xdg-App control field to %s'), $appid);
+	    $fields->{'Xdg-App'} = $appid;
+	} else {
+	    warning(_g('desktop appdata file %s has no <id> node',
+		       $appdata[0]));
 	}
 
     } else {

--- a/scripts/dpkg-buildpackage.pl
+++ b/scripts/dpkg-buildpackage.pl
@@ -475,7 +475,10 @@ if ($signsource && build_binaryonly) {
 # Determine prefix for the environment
 my $prefix = '/usr';
 @build_profiles = get_build_profiles();
-if (grep {/^eos-app$/} @build_profiles) {
+if (grep {/^xdg-app$/} @build_profiles) {
+    # Xdg-Apps always use /app prefix
+    $prefix = '/app';
+} elsif (grep {/^eos-app$/} @build_profiles) {
     my $control = Dpkg::Control::Info->new();
     my $mainpackage = $control->get_pkg_by_idx(1);
     my $app_id = $mainpackage->{'Xcbs-Eos-Appid'} || $mainpackage->{'Package'};
@@ -483,8 +486,8 @@ if (grep {/^eos-app$/} @build_profiles) {
 }
 $ENV{DEB_PREFIX} = $prefix;
 
-# Add to default search paths for eos-app profiles
-if (grep {/^eos-app$/} @build_profiles) {
+# Add to default search paths for app profiles
+if ($prefix ne '/usr') {
     # PATH
     $ENV{PATH} = $prefix . "/bin:" . $ENV{PATH};
 

--- a/scripts/dpkg-buildpackage.pl
+++ b/scripts/dpkg-buildpackage.pl
@@ -475,7 +475,7 @@ if ($signsource && build_binaryonly) {
 # Determine prefix for the environment
 my $prefix = '/usr';
 @build_profiles = get_build_profiles();
-if ("eos-app" ~~ @build_profiles) {
+if (grep {/^eos-app$/} @build_profiles) {
     my $control = Dpkg::Control::Info->new();
     my $mainpackage = $control->get_pkg_by_idx(1);
     my $app_id = $mainpackage->{'Xcbs-Eos-Appid'} || $mainpackage->{'Package'};
@@ -484,7 +484,7 @@ if ("eos-app" ~~ @build_profiles) {
 $ENV{DEB_PREFIX} = $prefix;
 
 # Add to default search paths for eos-app profiles
-if ("eos-app" ~~ @build_profiles) {
+if (grep {/^eos-app$/} @build_profiles) {
     # PATH
     $ENV{PATH} = $prefix . "/bin:" . $ENV{PATH};
 

--- a/scripts/dpkg-gencontrol.pl
+++ b/scripts/dpkg-gencontrol.pl
@@ -39,6 +39,7 @@ use Dpkg::Substvars;
 use Dpkg::Vars;
 use Dpkg::Changelog::Parse;
 use Dpkg::Dist::Files;
+use Dpkg::Vendor qw(run_vendor_hook);
 
 textdomain('dpkg-dev');
 
@@ -362,6 +363,9 @@ if (defined($substvars->get('Extra-Size'))) {
 if (defined($substvars->get('Installed-Size'))) {
     $fields->{'Installed-Size'} = $substvars->get('Installed-Size');
 }
+
+# Let the vendor update the control fields
+run_vendor_hook('update-binary-control-fields', $fields, $packagebuilddir);
 
 for my $f (keys %override) {
     $fields->{$f} = $override{$f};


### PR DESCRIPTION
Setup the environment correctly for xdg-app building in /app when "xdg-app" is in DEB_BUILD_PROFILES. This also adds the "Xdg-App" field to the binary control file when an application appdata file is installed.

[endlessm/eos-shell#6290]
